### PR TITLE
More Autosplitters

### DIFF
--- a/src/BaseBakkesModPlugin.h
+++ b/src/BaseBakkesModPlugin.h
@@ -1,8 +1,9 @@
 #pragma once
 
 #include <bakkesmod/plugin/pluginwindow.h>
+#include "NetcodePlugin.h"
 
-class BaseBakkesModPlugin : public BakkesMod::Plugin::BakkesModPlugin, public BakkesMod::Plugin::PluginWindow
+class BaseBakkesModPlugin : public NetcodePlugin, public BakkesMod::Plugin::PluginWindow
 {
 protected:
     const std::string menuTitle;

--- a/src/NetcodePlugin.h
+++ b/src/NetcodePlugin.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "bakkesmod/plugin/bakkesmodplugin.h"
+#include "utils/NetcodeManager.h"
+#include <memory>
+
+class NetcodePlugin : public BakkesMod::Plugin::BakkesModPlugin
+{
+protected:
+	std::shared_ptr<NetcodeManager> Netcode;
+
+public:
+	virtual void NotifyPlayers(std::string message) = 0;
+};

--- a/src/SpeedrunTools.cpp
+++ b/src/SpeedrunTools.cpp
@@ -47,12 +47,12 @@ void SpeedrunTools::onUnload()
 
 void SpeedrunTools::renderBody()
 {
-    static bool showDemoWindow = false;
+    /*static bool showDemoWindow = false;
     ImGui::Checkbox("Show Demo Window", &showDemoWindow);
     if (showDemoWindow)
     {
         ImGui::ShowDemoWindow();
-    }
+    }*/
 
     ImGui::Text("%s (version %s)", PLUGIN_TITLE, PLUGIN_VERSION);
     ImGui::Spacing();
@@ -138,6 +138,8 @@ void SpeedrunTools::MessageRecieved(const std::string& message, PriWrapper sende
     if (!curCar) return;
     auto curPri = curCar.GetPRI();
     if (!curPri) return;
+
+    //Don't duplicate splits for the sender
     if (sender.GetPlayerID() == curPri.GetPlayerID()) return;
 
     if (message == "Start") {

--- a/src/SpeedrunTools.cpp
+++ b/src/SpeedrunTools.cpp
@@ -117,7 +117,7 @@ void SpeedrunTools::setupEvents()
     // modal popup
     this->setupEventPost("Function TAGame.GFxShell_TA.ShowModalObject");
 
-    // dribble challenge end
+    // goal scored function
     this->setupEventPost("Function TAGame.Ball_TA.Explode");
 }
 

--- a/src/SpeedrunTools.h
+++ b/src/SpeedrunTools.h
@@ -21,7 +21,11 @@ public:
     void renderBody() override;
     void renderCanvas(CanvasWrapper &canvasWrapper);
 
+    void NotifyPlayers(std::string message) override;
+
 private:
     void setupEvents();
     void setupEventPost(const std::string &eventName);
+
+    void MessageRecieved(const std::string& message, PriWrapper sender);
 };

--- a/src/components/PluginComponentBase.cpp
+++ b/src/components/PluginComponentBase.cpp
@@ -1,6 +1,6 @@
 #include "PluginComponentBase.h"
 
-PluginComponentBase::PluginComponentBase(BakkesMod::Plugin::BakkesModPlugin *plugin) : plugin(plugin)
+PluginComponentBase::PluginComponentBase(NetcodePlugin* plugin) : plugin(plugin)
 {
 
 }

--- a/src/components/PluginComponentBase.h
+++ b/src/components/PluginComponentBase.h
@@ -1,14 +1,15 @@
 #pragma once
 
 #include "../PluginComponent.h"
+#include "../NetcodePlugin.h"
 
 class PluginComponentBase : public PluginComponent
 {
 protected:
-    BakkesMod::Plugin::BakkesModPlugin *plugin;
+    NetcodePlugin *plugin;
 
 public:
-    explicit PluginComponentBase(BakkesMod::Plugin::BakkesModPlugin *plugin);
+    explicit PluginComponentBase(NetcodePlugin* plugin);
 
     void onEvent(const std::string &eventName, bool post, void *params) override;
 

--- a/src/components/experimental/ExperimentalComponent.cpp
+++ b/src/components/experimental/ExperimentalComponent.cpp
@@ -1,6 +1,6 @@
 #include "ExperimentalComponent.h"
 
-ExperimentalComponent::ExperimentalComponent(BakkesMod::Plugin::BakkesModPlugin *plugin)
+ExperimentalComponent::ExperimentalComponent(NetcodePlugin *plugin)
         : PluginComponentBase(plugin), vars()
 {
 

--- a/src/components/experimental/ExperimentalComponent.h
+++ b/src/components/experimental/ExperimentalComponent.h
@@ -8,7 +8,7 @@ class ExperimentalComponent : public PluginComponentBase
 public:
     std::vector<TestVar> vars;
 
-    explicit ExperimentalComponent(BakkesMod::Plugin::BakkesModPlugin *plugin);
+    explicit ExperimentalComponent(NetcodePlugin *plugin);
 
     void onEvent(const std::string &eventName, bool post, void *params) override;
 

--- a/src/components/generaltools/GeneralToolsComponent.cpp
+++ b/src/components/generaltools/GeneralToolsComponent.cpp
@@ -5,7 +5,7 @@ const std::string GeneralToolsComponent::AirRollMutatorCVarName = "speedrun_muta
 const std::string GeneralToolsComponent::GameGravityMutatorCVarName = "speedrun_mutator_game_gravity";
 const std::string GeneralToolsComponent::GameSpeedMutatorCVarName = "speedrun_mutator_game_speed";
 
-GeneralToolsComponent::GeneralToolsComponent(BakkesMod::Plugin::BakkesModPlugin *plugin)
+GeneralToolsComponent::GeneralToolsComponent(NetcodePlugin *plugin)
         : PluginComponentBase(plugin),
           currentGameState(),
           boostMutator(BoostMutator::None),

--- a/src/components/generaltools/GeneralToolsComponent.h
+++ b/src/components/generaltools/GeneralToolsComponent.h
@@ -32,7 +32,7 @@ private:
     AirRollMutator airRollMutator;
 
 public:
-    explicit GeneralToolsComponent(BakkesMod::Plugin::BakkesModPlugin *plugin);
+    explicit GeneralToolsComponent(NetcodePlugin *plugin);
 
     void render() override;
     void onEvent(const std::string &eventName, bool post, void *params) override;

--- a/src/components/kismet/KismetEditorComponent.cpp
+++ b/src/components/kismet/KismetEditorComponent.cpp
@@ -2,7 +2,7 @@
 
 const std::string KismetEditorComponent::ListAllCVarsNotifier = "speedrun_kismet_list";
 
-KismetEditorComponent::KismetEditorComponent(BakkesMod::Plugin::BakkesModPlugin *plugin)
+KismetEditorComponent::KismetEditorComponent(NetcodePlugin *plugin)
         : PluginComponentBase(plugin),
           kismetModel(KismetModel::getInstance(plugin))
 {

--- a/src/components/kismet/KismetEditorComponent.h
+++ b/src/components/kismet/KismetEditorComponent.h
@@ -13,7 +13,7 @@ private:
     KismetModel &kismetModel;
 
 public:
-    explicit KismetEditorComponent(BakkesMod::Plugin::BakkesModPlugin *plugin);
+    explicit KismetEditorComponent(NetcodePlugin *plugin);
 
     void onEvent(const std::string &eventName, bool post, void *params) override;
     void render() override;

--- a/src/components/livesplit/LiveSplitComponent.cpp
+++ b/src/components/livesplit/LiveSplitComponent.cpp
@@ -11,7 +11,7 @@ const std::string LiveSplitComponent::SplitCVarName = "speedrun_livesplit_split"
 const std::string LiveSplitComponent::SkipSplitCVarName = "speedrun_livesplit_skipsplit";
 const std::string LiveSplitComponent::UndoSplitCVarName = "speedrun_livesplit_undosplit";
 
-LiveSplitComponent::LiveSplitComponent(BakkesMod::Plugin::BakkesModPlugin *plugin)
+LiveSplitComponent::LiveSplitComponent(NetcodePlugin *plugin)
         : PluginComponentBase(plugin),
           liveSplitModel(LiveSplitModel::getInstance(plugin))
 {

--- a/src/components/livesplit/LiveSplitComponent.h
+++ b/src/components/livesplit/LiveSplitComponent.h
@@ -22,7 +22,7 @@ private:
     LiveSplitModel &liveSplitModel;
 
 public:
-    explicit LiveSplitComponent(BakkesMod::Plugin::BakkesModPlugin *plugin);
+    explicit LiveSplitComponent(NetcodePlugin *plugin);
 
     void render() override;
 

--- a/src/components/maptools/AutoSplitterComponent.cpp
+++ b/src/components/maptools/AutoSplitterComponent.cpp
@@ -104,6 +104,11 @@ void AutoSplitterComponent::onMapReset()
     this->reset();
 }
 
+void AutoSplitterComponent::disable()
+{
+    this->isEnabled = false;
+}
+
 void AutoSplitterComponent::onEnable()
 {
 

--- a/src/components/maptools/AutoSplitterComponent.cpp
+++ b/src/components/maptools/AutoSplitterComponent.cpp
@@ -1,6 +1,6 @@
 #include "AutoSplitterComponent.h"
 
-AutoSplitterComponent::AutoSplitterComponent(BakkesMod::Plugin::BakkesModPlugin *plugin)
+AutoSplitterComponent::AutoSplitterComponent(NetcodePlugin *plugin)
         : PluginComponentBase(plugin),
           liveSplitModel(LiveSplitModel::getInstance(plugin)),
           kismetModel(KismetModel::getInstance(plugin)),
@@ -10,7 +10,7 @@ AutoSplitterComponent::AutoSplitterComponent(BakkesMod::Plugin::BakkesModPlugin 
           isAutoResetEnabled(true),
           segment(0)
 {
-
+    
 }
 
 void AutoSplitterComponent::onEvent(const std::string &eventName, bool post, void *params)
@@ -59,9 +59,9 @@ void AutoSplitterComponent::render()
             }
             ImGuiExtensions::BigSpacing();
 
-            std::string debug = this->getDebugTextPrefix() + this->getDebugText();
+            /*std::string debug = this->getDebugTextPrefix() + this->getDebugText();
             ImGui::InputTextMultiline("Debug Output", (char *) debug.c_str(), debug.capacity() + 1, ImVec2(0, ImGui::GetTextLineHeight() * 8),
-                                      ImGuiInputTextFlags_ReadOnly);
+                                      ImGuiInputTextFlags_ReadOnly);*/
         }
         else
         {
@@ -109,22 +109,25 @@ void AutoSplitterComponent::onEnable()
 
 }
 
-void AutoSplitterComponent::start()
+void AutoSplitterComponent::start(bool netcode)
 {
     this->segment = 1;
     if (this->liveSplitModel.isConnected() && this->isEnabled && this->isAutoStartEnabled) this->liveSplitModel.start();
+    if (netcode) this->plugin->NotifyPlayers("Start");
 }
 
-void AutoSplitterComponent::split()
+void AutoSplitterComponent::split(bool netcode)
 {
     this->segment++;
     if (this->liveSplitModel.isConnected() && this->isEnabled && this->isAutoSplitEnabled) this->liveSplitModel.split();
+    if (netcode) this->plugin->NotifyPlayers("Split");
 }
 
-void AutoSplitterComponent::reset()
+void AutoSplitterComponent::reset(bool netcode)
 {
     this->segment = 0;
     if (this->liveSplitModel.isConnected() && this->isEnabled && this->isAutoResetEnabled) this->liveSplitModel.reset();
+    if (netcode) this->plugin->NotifyPlayers("Reset");
 }
 
 std::string AutoSplitterComponent::getStartDescription()

--- a/src/components/maptools/AutoSplitterComponent.h
+++ b/src/components/maptools/AutoSplitterComponent.h
@@ -18,7 +18,7 @@ protected:
     int segment;
 
 public:
-    explicit AutoSplitterComponent(BakkesMod::Plugin::BakkesModPlugin *plugin);
+    explicit AutoSplitterComponent(NetcodePlugin *plugin);
 
     void onEvent(const std::string &eventName, bool post, void *params) final;
     void render() final;
@@ -33,9 +33,9 @@ protected:
     virtual void onEnable();
     virtual void update(const std::string &eventName, bool post, void *params) = 0;
 
-    void start();
-    void split();
-    void reset();
+    void start(bool netcode = false);
+    void split(bool netcode = false);
+    void reset(bool netcode = false);
 
     virtual std::string getStartDescription();
     virtual std::string getSplitDescription();

--- a/src/components/maptools/AutoSplitterComponent.h
+++ b/src/components/maptools/AutoSplitterComponent.h
@@ -24,6 +24,7 @@ public:
     void render() final;
 
     virtual void onMapReset();
+    void disable();
 
 private:
     void renderConnectView();

--- a/src/components/maptools/MapToolsComponent.cpp
+++ b/src/components/maptools/MapToolsComponent.cpp
@@ -2,7 +2,7 @@
 
 #include <utility>
 
-MapToolsComponent::MapToolsComponent(BakkesMod::Plugin::BakkesModPlugin *plugin, std::shared_ptr<AutoSplitterComponent> component,
+MapToolsComponent::MapToolsComponent(NetcodePlugin *plugin, std::shared_ptr<AutoSplitterComponent> component,
                                      std::string mapName, std::string cVarName, int numCheckpoints)
         : PluginComponentBase(plugin),
           mapToolsModel(MapToolsModel::getInstance(plugin)),
@@ -112,4 +112,9 @@ void MapToolsComponent::renderCanvas(CanvasWrapper &canvasWrapper)
 std::string MapToolsComponent::getMapName()
 {
     return this->mapName;
+}
+
+std::string MapToolsComponent::getCvar()
+{
+    return this->cVarName;
 }

--- a/src/components/maptools/MapToolsComponent.cpp
+++ b/src/components/maptools/MapToolsComponent.cpp
@@ -109,6 +109,11 @@ void MapToolsComponent::renderCanvas(CanvasWrapper &canvasWrapper)
     this->autoSplitterComponent->renderCanvas(canvasWrapper);
 }
 
+void MapToolsComponent::disableAutoSplitter()
+{
+    autoSplitterComponent->disable();
+}
+
 std::string MapToolsComponent::getMapName()
 {
     return this->mapName;

--- a/src/components/maptools/MapToolsComponent.h
+++ b/src/components/maptools/MapToolsComponent.h
@@ -24,6 +24,8 @@ public:
     void render() override;
     void renderCanvas(CanvasWrapper &canvasWrapper) override;
 
+    void disableAutoSplitter();
+
     std::string getMapName();
     std::string getCvar();
 

--- a/src/components/maptools/MapToolsComponent.h
+++ b/src/components/maptools/MapToolsComponent.h
@@ -17,7 +17,7 @@ protected:
     const int numCheckpoints;
 
 public:
-    MapToolsComponent(BakkesMod::Plugin::BakkesModPlugin *plugin, std::shared_ptr<AutoSplitterComponent> component,
+    MapToolsComponent(NetcodePlugin *plugin, std::shared_ptr<AutoSplitterComponent> component,
                       std::string mapName, std::string cVarName, int numCheckpoints);
 
     void onEvent(const std::string &eventName, bool post, void *params) override;
@@ -25,6 +25,7 @@ public:
     void renderCanvas(CanvasWrapper &canvasWrapper) override;
 
     std::string getMapName();
+    std::string getCvar();
 
 protected:
     virtual void createResetNotifier();

--- a/src/components/maptools/MapToolsSelectorComponent.cpp
+++ b/src/components/maptools/MapToolsSelectorComponent.cpp
@@ -9,8 +9,10 @@
 #include "leth/LethsGiantRingsMapToolsComponent.h"
 #include "speedjump/trials/SpeedJumpTrials1MapToolsComponent.h"
 #include "airdribble/AirDribbleHoopsMapToolsComponent.h"
+#include "dribble/Dribble2OverhaulMapToolsComponent.h"
+#include "leth/LethsEgyptianTombMapToolsComponent.h"
 
-MapToolsSelectorComponent::MapToolsSelectorComponent(BakkesMod::Plugin::BakkesModPlugin *plugin)
+MapToolsSelectorComponent::MapToolsSelectorComponent(NetcodePlugin *plugin)
         : PluginComponentBase(plugin),
           maps(),
           selectedMapIndex(0)
@@ -24,7 +26,20 @@ MapToolsSelectorComponent::MapToolsSelectorComponent(BakkesMod::Plugin::BakkesMo
     this->maps.push_back(std::make_unique<SpeedJumpRings1MapToolsComponent>(plugin));
     this->maps.push_back(std::make_unique<SpeedJumpRings2MapToolsComponent>(plugin));
     this->maps.push_back(std::make_unique<SpeedJumpRings3MapToolsComponent>(plugin));
+    this->maps.push_back(std::make_unique<Dribble2OverhaulMapToolsComponent>(plugin));
+    this->maps.push_back(std::make_unique<LethsEgyptianTombMapToolsComponent>(plugin));
     //this->maps.push_back(std::make_unique<SpeedJumpTrials1MapToolsComponent>(plugin));
+
+    this->plugin->cvarManager->registerNotifier("speedrun_maptools_global_reset", [this](const std::vector<std::string>& commands) {
+        for (int i = 0; i < this->maps.size(); i++)
+        {
+            if (i == this->selectedMapIndex)
+            {
+                this->plugin->cvarManager->executeCommand("speedrun_maptools_" + this->maps.at(i)->getCvar() + "_reset");
+                return;
+            }
+        }
+        }, "", PERMISSION_PAUSEMENU_CLOSED);
 }
 
 void MapToolsSelectorComponent::onEvent(const std::string &eventName, bool post, void *params)

--- a/src/components/maptools/MapToolsSelectorComponent.cpp
+++ b/src/components/maptools/MapToolsSelectorComponent.cpp
@@ -12,6 +12,7 @@
 #include "dribble/Dribble2OverhaulMapToolsComponent.h"
 #include "leth/LethsEgyptianTombMapToolsComponent.h"
 #include "minigolf/MinigolfMapToolsComponent.h"
+#include "../../external/ocornut/imgui/imgui_searchablecombo.h"
 
 MapToolsSelectorComponent::MapToolsSelectorComponent(NetcodePlugin *plugin)
         : PluginComponentBase(plugin),
@@ -31,6 +32,13 @@ MapToolsSelectorComponent::MapToolsSelectorComponent(NetcodePlugin *plugin)
     this->maps.push_back(std::make_unique<LethsEgyptianTombMapToolsComponent>(plugin));
     this->maps.push_back(std::make_unique<MinigolfMapToolsComponent>(plugin));
     //this->maps.push_back(std::make_unique<SpeedJumpTrials1MapToolsComponent>(plugin));
+
+    this->mapNames = {};
+    this->mapNames.reserve(this->maps.size());
+    for (const auto& map : maps) 
+    {
+        this->mapNames.push_back(map->getMapName());
+    }
 
     this->plugin->cvarManager->registerNotifier("speedrun_maptools_global_reset", [this](const std::vector<std::string>& commands) {
         for (int i = 0; i < this->maps.size(); i++)
@@ -57,21 +65,14 @@ void MapToolsSelectorComponent::render()
     ImGui::Text("Choose a map:");
     ImGui::Spacing();
 
-    if (ImGui::BeginCombo("map", this->maps.at(this->selectedMapIndex)->getMapName().c_str()))
-    {
+    if (ImGui::SearchableCombo("map", &this->selectedMapIndex, mapNames, "", "")) {
         for (int i = 0; i < this->maps.size(); i++)
         {
-            bool isSelected = this->selectedMapIndex == i;
-            if (ImGui::Selectable(this->maps.at(i)->getMapName().c_str(), isSelected))
-                this->selectedMapIndex = i;
-            if (isSelected)
-                ImGui::SetItemDefaultFocus();
-            else
+            if (this->selectedMapIndex != i)
                 this->maps.at(i)->disableAutoSplitter();
-            //added in to disable other autosplitters when you switch to a new one
         }
-        ImGui::EndCombo();
     }
+    
     ImGuiExtensions::BigSeparator();
 
     this->maps.at(selectedMapIndex)->render();

--- a/src/components/maptools/MapToolsSelectorComponent.cpp
+++ b/src/components/maptools/MapToolsSelectorComponent.cpp
@@ -66,6 +66,9 @@ void MapToolsSelectorComponent::render()
                 this->selectedMapIndex = i;
             if (isSelected)
                 ImGui::SetItemDefaultFocus();
+            else
+                this->maps.at(i)->disableAutoSplitter();
+            //added in to disable other autosplitters when you switch to a new one
         }
         ImGui::EndCombo();
     }

--- a/src/components/maptools/MapToolsSelectorComponent.cpp
+++ b/src/components/maptools/MapToolsSelectorComponent.cpp
@@ -11,6 +11,7 @@
 #include "airdribble/AirDribbleHoopsMapToolsComponent.h"
 #include "dribble/Dribble2OverhaulMapToolsComponent.h"
 #include "leth/LethsEgyptianTombMapToolsComponent.h"
+#include "minigolf/MinigolfMapToolsComponent.h"
 
 MapToolsSelectorComponent::MapToolsSelectorComponent(NetcodePlugin *plugin)
         : PluginComponentBase(plugin),
@@ -28,6 +29,7 @@ MapToolsSelectorComponent::MapToolsSelectorComponent(NetcodePlugin *plugin)
     this->maps.push_back(std::make_unique<SpeedJumpRings3MapToolsComponent>(plugin));
     this->maps.push_back(std::make_unique<Dribble2OverhaulMapToolsComponent>(plugin));
     this->maps.push_back(std::make_unique<LethsEgyptianTombMapToolsComponent>(plugin));
+    this->maps.push_back(std::make_unique<MinigolfMapToolsComponent>(plugin));
     //this->maps.push_back(std::make_unique<SpeedJumpTrials1MapToolsComponent>(plugin));
 
     this->plugin->cvarManager->registerNotifier("speedrun_maptools_global_reset", [this](const std::vector<std::string>& commands) {

--- a/src/components/maptools/MapToolsSelectorComponent.h
+++ b/src/components/maptools/MapToolsSelectorComponent.h
@@ -10,7 +10,7 @@ private:
     int selectedMapIndex;
 
 public:
-    explicit MapToolsSelectorComponent(BakkesMod::Plugin::BakkesModPlugin *plugin);
+    explicit MapToolsSelectorComponent(NetcodePlugin *plugin);
 
     void onEvent(const std::string &eventName, bool post, void *params) override;
 

--- a/src/components/maptools/MapToolsSelectorComponent.h
+++ b/src/components/maptools/MapToolsSelectorComponent.h
@@ -7,6 +7,7 @@ class MapToolsSelectorComponent : public PluginComponentBase
 {
 private:
     std::vector<std::unique_ptr<MapToolsComponent>> maps;
+    std::vector<std::string> mapNames;
     int selectedMapIndex;
 
 public:

--- a/src/components/maptools/airdribble/AirDribbleHoopsAutoSplitterComponent.cpp
+++ b/src/components/maptools/airdribble/AirDribbleHoopsAutoSplitterComponent.cpp
@@ -1,6 +1,6 @@
 #include "AirDribbleHoopsAutoSplitterComponent.h"
 
-AirDribbleHoopsAutoSplitterComponent::AirDribbleHoopsAutoSplitterComponent(BakkesMod::Plugin::BakkesModPlugin *plugin)
+AirDribbleHoopsAutoSplitterComponent::AirDribbleHoopsAutoSplitterComponent(NetcodePlugin *plugin)
         : AutoSplitterComponent(plugin),
           timer(),
           level()
@@ -63,7 +63,7 @@ std::string AirDribbleHoopsAutoSplitterComponent::getSplitDescription()
 
 std::string AirDribbleHoopsAutoSplitterComponent::getResetDescription()
 {
-    return "The timer will reset after pressing the reset map button or leaving the match.";
+    return "The timer will reset after leaving the match.";
 }
 
 std::string AirDribbleHoopsAutoSplitterComponent::getDebugText()

--- a/src/components/maptools/airdribble/AirDribbleHoopsAutoSplitterComponent.cpp
+++ b/src/components/maptools/airdribble/AirDribbleHoopsAutoSplitterComponent.cpp
@@ -58,7 +58,7 @@ std::string AirDribbleHoopsAutoSplitterComponent::getStartDescription()
 
 std::string AirDribbleHoopsAutoSplitterComponent::getSplitDescription()
 {
-    return "The timer will split after completing each level.";
+    return "The timer will split after completing each level (21 splits in total).";
 }
 
 std::string AirDribbleHoopsAutoSplitterComponent::getResetDescription()

--- a/src/components/maptools/airdribble/AirDribbleHoopsAutoSplitterComponent.h
+++ b/src/components/maptools/airdribble/AirDribbleHoopsAutoSplitterComponent.h
@@ -7,7 +7,7 @@ private:
     int level;
 
 public:
-    explicit AirDribbleHoopsAutoSplitterComponent(BakkesMod::Plugin::BakkesModPlugin *plugin);
+    explicit AirDribbleHoopsAutoSplitterComponent(NetcodePlugin *plugin);
 
     void onEnable() override;
     void update(const std::string &eventName, bool post, void *params) override;

--- a/src/components/maptools/airdribble/AirDribbleHoopsMapToolsComponent.cpp
+++ b/src/components/maptools/airdribble/AirDribbleHoopsMapToolsComponent.cpp
@@ -1,7 +1,7 @@
 #include "AirDribbleHoopsMapToolsComponent.h"
 #include "AirDribbleHoopsAutoSplitterComponent.h"
 
-AirDribbleHoopsMapToolsComponent::AirDribbleHoopsMapToolsComponent(BakkesMod::Plugin::BakkesModPlugin *plugin)
+AirDribbleHoopsMapToolsComponent::AirDribbleHoopsMapToolsComponent(NetcodePlugin *plugin)
         : MapToolsComponent(plugin, std::make_shared<AirDribbleHoopsAutoSplitterComponent>(plugin),
                             "Air Dribble Hoops", "airhoops", 0)
 {

--- a/src/components/maptools/airdribble/AirDribbleHoopsMapToolsComponent.h
+++ b/src/components/maptools/airdribble/AirDribbleHoopsMapToolsComponent.h
@@ -3,7 +3,7 @@
 class AirDribbleHoopsMapToolsComponent : public MapToolsComponent
 {
 public:
-    explicit AirDribbleHoopsMapToolsComponent(BakkesMod::Plugin::BakkesModPlugin *plugin);
+    explicit AirDribbleHoopsMapToolsComponent(NetcodePlugin *plugin);
 
 protected:
     void resetMap() override;

--- a/src/components/maptools/dribble/Dribble2OverhaulAutoSplitterComponent.cpp
+++ b/src/components/maptools/dribble/Dribble2OverhaulAutoSplitterComponent.cpp
@@ -1,0 +1,71 @@
+#include "Dribble2OverhaulAutoSplitterComponent.h"
+
+Dribble2OverhaulAutoSplitterComponent::Dribble2OverhaulAutoSplitterComponent(NetcodePlugin* plugin)
+    : AutoSplitterComponent(plugin),
+    checkpoint(),
+    timing()
+{
+
+}
+
+void Dribble2OverhaulAutoSplitterComponent::onEnable()
+{
+    this->checkpoint = this->kismetModel.getIntValue("Level");
+    this->timing = this->kismetModel.getBoolValue("Timing");
+}
+
+void Dribble2OverhaulAutoSplitterComponent::update(const std::string& eventName, bool post, void* params)
+{
+    if (eventName == "Function TAGame.Car_TA.SetVehicleInput" && post)
+    {
+        int previousCheckpoint = this->checkpoint;
+        this->checkpoint = this->kismetModel.getIntValue("Level");
+
+        bool previousTiming = this->timing;
+        this->timing = this->kismetModel.getBoolValue("Timing");
+
+        if (this->segment == 0)
+        {
+            if(this->timing && !previousTiming)
+                this->start();
+        }
+        else if (this->segment > 0 && this->segment <= 29)
+        {
+            if (this->checkpoint == (previousCheckpoint + 1) && this->checkpoint == (this->segment + 1))
+                this->split();
+        }
+    }
+    if (eventName == "Function TAGame.GameEvent_Soccar_TA.Destroyed" && post)
+    {
+        this->reset();
+    }
+    if (eventName == "Function TAGame.Ball_TA.Explode" && post)
+    {
+        if (this->segment == 30)
+            this->split();
+    }
+}
+
+std::string Dribble2OverhaulAutoSplitterComponent::getStartDescription()
+{
+    return "The timer will start when you hit the timer box.";
+}
+
+std::string Dribble2OverhaulAutoSplitterComponent::getSplitDescription()
+{
+    return "The timer will split when the ball hits each of the goals and ends on the final goal. (30 splits in total).";
+}
+
+std::string Dribble2OverhaulAutoSplitterComponent::getResetDescription()
+{
+    return "The timer will reset after leaving the match.";
+}
+
+std::string Dribble2OverhaulAutoSplitterComponent::getDebugText()
+{
+    std::stringstream ss;
+    ss << "Dribble Challenge 2 Auto Splitter (Debug)" << std::endl;
+    ss << "checkpoint = " << this->checkpoint << std::endl;
+    ss << "timing = " << this->timing << std::endl;
+    return ss.str();
+}

--- a/src/components/maptools/dribble/Dribble2OverhaulAutoSplitterComponent.h
+++ b/src/components/maptools/dribble/Dribble2OverhaulAutoSplitterComponent.h
@@ -1,20 +1,19 @@
 #pragma once
 
 #include "../AutoSplitterComponent.h"
-#include "../../../services/LiveSplitClient.h"
 
-class LethsNeonRingsAutoSplitterComponent : public AutoSplitterComponent
+class Dribble2OverhaulAutoSplitterComponent : public AutoSplitterComponent
 {
 private:
+    int checkpoint;
     bool timing;
-    int level;
 
 public:
-    explicit LethsNeonRingsAutoSplitterComponent(NetcodePlugin *plugin);
+    explicit Dribble2OverhaulAutoSplitterComponent(NetcodePlugin* plugin);
 
 protected:
     void onEnable() override;
-    void update(const std::string &eventName, bool post, void *params) override;
+    void update(const std::string& eventName, bool post, void* params) override;
 
     std::string getStartDescription() override;
     std::string getSplitDescription() override;

--- a/src/components/maptools/dribble/Dribble2OverhaulMapToolsComponent.cpp
+++ b/src/components/maptools/dribble/Dribble2OverhaulMapToolsComponent.cpp
@@ -1,0 +1,19 @@
+#include "Dribble2OverhaulMapToolsComponent.h"
+#include "Dribble2OverhaulAutoSplitterComponent.h"
+
+Dribble2OverhaulMapToolsComponent::Dribble2OverhaulMapToolsComponent(NetcodePlugin* plugin)
+    : MapToolsComponent(plugin, std::make_shared<Dribble2OverhaulAutoSplitterComponent>(plugin),
+        "Dribble Challenge 2 Overhaul", "dribble2overhaul", 0)
+{
+
+}
+
+void Dribble2OverhaulMapToolsComponent::resetMap()
+{
+    this->plugin->gameWrapper->ExecuteUnrealCommand("servertravel ?");
+}
+
+void Dribble2OverhaulMapToolsComponent::checkpoint(int checkpoint)
+{
+
+}

--- a/src/components/maptools/dribble/Dribble2OverhaulMapToolsComponent.h
+++ b/src/components/maptools/dribble/Dribble2OverhaulMapToolsComponent.h
@@ -2,13 +2,12 @@
 
 #include "../MapToolsComponent.h"
 
-class TutorialBasicMapToolsComponent : public MapToolsComponent
+class Dribble2OverhaulMapToolsComponent : public MapToolsComponent
 {
 public:
-    explicit TutorialBasicMapToolsComponent(NetcodePlugin *plugin);
+    explicit Dribble2OverhaulMapToolsComponent(NetcodePlugin* plugin);
 
 protected:
     void resetMap() override;
     void checkpoint(int checkpoint) override;
 };
-

--- a/src/components/maptools/leth/LethsEgyptianTombAutoSplitterComponent.cpp
+++ b/src/components/maptools/leth/LethsEgyptianTombAutoSplitterComponent.cpp
@@ -1,0 +1,112 @@
+#include "LethsEgyptianTombAutoSplitterComponent.h"
+
+LethsEgyptianTombAutoSplitterComponent::LethsEgyptianTombAutoSplitterComponent(NetcodePlugin* plugin)
+    : AutoSplitterComponent(plugin),
+    ankhs()
+{
+}
+
+void LethsEgyptianTombAutoSplitterComponent::onEnable()
+{
+    this->ankhs = this->kismetModel.getIntValue("ankh");
+}
+
+void LethsEgyptianTombAutoSplitterComponent::update(const std::string& eventName, bool post, void* params)
+{
+    if (eventName == "Function TAGame.Car_TA.SetVehicleInput" && post)
+    {
+        int previousAnkh = this->ankhs;
+        this->ankhs = this->kismetModel.getIntValue("ankh");
+
+        auto server = this->plugin->gameWrapper->GetGameEventAsServer();
+        if (!server) return;
+        auto cars = server.GetCars();
+        if (cars.IsNull()) return;
+
+        if (this->segment == 0)
+        {
+            std::vector<int> pris;
+            for (int i = 0; i < cars.Count(); i++) {
+                auto car = cars.Get(i);
+                if (car.IsNull()) continue;
+                auto pri = car.GetPRI();
+                if (pri.IsNull()) continue;
+                pris.push_back(pri.GetPlayerID());
+                if (this->segment == 0 && car.GetLocation().Y >= 5460.0f)
+                {
+                    this->start(true);
+                }
+            }
+            if (this->segment == 1) {
+                this->priFinishedMap.clear();
+                for (auto& pri : pris)
+                    this->priFinishedMap[pri] = false;
+            }
+        }
+        else if (1 <= this->segment && this->segment <= 6)
+        {
+            if (this->ankhs >= (previousAnkh + 1) && this->ankhs >= (this->segment + (4 * this->segment)))
+                this->split(true);
+        }
+        else if (this->segment == 7)
+        {
+            for (int i = 0; i < cars.Count(); i++) {
+                auto car = cars.Get(i);
+                if (car.IsNull()) continue;
+                float x = car.GetLocation().X;
+                float y = car.GetLocation().Y;
+                if (x > 25480.0f && x < 26710.0f && y > -8080.0f && y < -5920.0f && this->segment == 7)
+                {
+                    this->split(true);
+                    return;
+                }
+            }
+        }
+        else if (this->segment == 8)
+        {
+            for (int i = 0; i < cars.Count(); i++) {
+                auto car = cars.Get(i);
+                if (car.IsNull()) continue;
+                auto pri = car.GetPRI();
+                if (pri.IsNull()) continue;
+                int id = pri.GetPlayerID();
+                if (this->priFinishedMap.find(id) == this->priFinishedMap.end()) continue;
+                if (!this->priFinishedMap[id] && car.GetLocation().Z > 10450.0f) {
+                    this->priFinishedMap[id] = true;
+                }
+            }
+            for (const auto& elem : this->priFinishedMap) {
+                if (!elem.second) return;
+            }
+            this->split(true);
+        }
+    }
+    if (eventName == "Function TAGame.GameEvent_Soccar_TA.Destroyed" && post)
+    {
+        this->reset(true);
+        this->priFinishedMap.clear();
+    }
+}
+
+std::string LethsEgyptianTombAutoSplitterComponent::getStartDescription()
+{
+    return "The timer will start when you cross the barrier at the start.";
+}
+
+std::string LethsEgyptianTombAutoSplitterComponent::getSplitDescription()
+{
+    return "The timer will split every 5 ankhs collected, gaining access to the secret room,\n and once all players complete the true ending (8 splits in total).";
+}
+
+std::string LethsEgyptianTombAutoSplitterComponent::getResetDescription()
+{
+    return "The timer will reset after leaving the map.";
+}
+
+std::string LethsEgyptianTombAutoSplitterComponent::getDebugText()
+{
+    std::stringstream ss;
+    ss << "Leth's Egyptian Tomb Auto Splitter (Debug)" << std::endl;
+    ss << "ankh = " << this->ankhs << std::endl;
+    return ss.str();
+}

--- a/src/components/maptools/leth/LethsEgyptianTombAutoSplitterComponent.h
+++ b/src/components/maptools/leth/LethsEgyptianTombAutoSplitterComponent.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "../AutoSplitterComponent.h"
+#include <map>
+
+class LethsEgyptianTombAutoSplitterComponent : public AutoSplitterComponent
+{
+private:
+    int ankhs;
+    std::map<int, bool> priFinishedMap = {};
+
+public:
+    explicit LethsEgyptianTombAutoSplitterComponent(NetcodePlugin* plugin);
+
+protected:
+    void onEnable() override;
+    void update(const std::string& eventName, bool post, void* params) override;
+
+    std::string getStartDescription() override;
+    std::string getSplitDescription() override;
+    std::string getResetDescription() override;
+    std::string getDebugText() override;
+};

--- a/src/components/maptools/leth/LethsEgyptianTombMapToolsComponent.cpp
+++ b/src/components/maptools/leth/LethsEgyptianTombMapToolsComponent.cpp
@@ -1,0 +1,19 @@
+#include "LethsEgyptianTombMapToolsComponent.h"
+#include "LethsEgyptianTombAutoSplitterComponent.h"
+
+LethsEgyptianTombMapToolsComponent::LethsEgyptianTombMapToolsComponent(NetcodePlugin* plugin)
+    : MapToolsComponent(plugin, std::make_shared<LethsEgyptianTombAutoSplitterComponent>(plugin),
+        "Leth's Egyptian Tomb", "lethstomb", 0)
+{
+
+}
+
+void LethsEgyptianTombMapToolsComponent::resetMap()
+{
+    this->plugin->gameWrapper->ExecuteUnrealCommand("servertravel ?");
+}
+
+void LethsEgyptianTombMapToolsComponent::checkpoint(int checkpoint)
+{
+
+}

--- a/src/components/maptools/leth/LethsEgyptianTombMapToolsComponent.h
+++ b/src/components/maptools/leth/LethsEgyptianTombMapToolsComponent.h
@@ -2,13 +2,12 @@
 
 #include "../MapToolsComponent.h"
 
-class TutorialBasicMapToolsComponent : public MapToolsComponent
+class LethsEgyptianTombMapToolsComponent : public MapToolsComponent
 {
 public:
-    explicit TutorialBasicMapToolsComponent(NetcodePlugin *plugin);
+    explicit LethsEgyptianTombMapToolsComponent(NetcodePlugin* plugin);
 
 protected:
     void resetMap() override;
     void checkpoint(int checkpoint) override;
 };
-

--- a/src/components/maptools/leth/LethsGiantRingsAutoSplitterComponent.cpp
+++ b/src/components/maptools/leth/LethsGiantRingsAutoSplitterComponent.cpp
@@ -1,6 +1,6 @@
 #include "LethsGiantRingsAutoSplitterComponent.h"
 
-LethsGiantRingsAutoSplitterComponent::LethsGiantRingsAutoSplitterComponent(BakkesMod::Plugin::BakkesModPlugin *plugin)
+LethsGiantRingsAutoSplitterComponent::LethsGiantRingsAutoSplitterComponent(NetcodePlugin *plugin)
         : AutoSplitterComponent(plugin),
           timing(),
           level()

--- a/src/components/maptools/leth/LethsGiantRingsAutoSplitterComponent.h
+++ b/src/components/maptools/leth/LethsGiantRingsAutoSplitterComponent.h
@@ -10,7 +10,7 @@ private:
     int level;
 
 public:
-    explicit LethsGiantRingsAutoSplitterComponent(BakkesMod::Plugin::BakkesModPlugin *plugin);
+    explicit LethsGiantRingsAutoSplitterComponent(NetcodePlugin *plugin);
 
 protected:
     void onEnable() override;

--- a/src/components/maptools/leth/LethsGiantRingsMapToolsComponent.cpp
+++ b/src/components/maptools/leth/LethsGiantRingsMapToolsComponent.cpp
@@ -1,7 +1,7 @@
 #include "LethsGiantRingsMapToolsComponent.h"
 #include "LethsGiantRingsAutoSplitterComponent.h"
 
-LethsGiantRingsMapToolsComponent::LethsGiantRingsMapToolsComponent(BakkesMod::Plugin::BakkesModPlugin *plugin)
+LethsGiantRingsMapToolsComponent::LethsGiantRingsMapToolsComponent(NetcodePlugin *plugin)
         : MapToolsComponent(plugin, std::make_shared<LethsGiantRingsAutoSplitterComponent>(plugin),
                             "Leth's Giant Rings", "lethsgiant", 20)
 {

--- a/src/components/maptools/leth/LethsGiantRingsMapToolsComponent.h
+++ b/src/components/maptools/leth/LethsGiantRingsMapToolsComponent.h
@@ -5,7 +5,7 @@
 class LethsGiantRingsMapToolsComponent : public MapToolsComponent
 {
 public:
-    explicit LethsGiantRingsMapToolsComponent(BakkesMod::Plugin::BakkesModPlugin *plugin);
+    explicit LethsGiantRingsMapToolsComponent(NetcodePlugin *plugin);
 
 protected:
     void resetMap() override;

--- a/src/components/maptools/leth/LethsNeonRingsAutoSplitterComponent.cpp
+++ b/src/components/maptools/leth/LethsNeonRingsAutoSplitterComponent.cpp
@@ -1,6 +1,6 @@
 #include "LethsNeonRingsAutoSplitterComponent.h"
 
-LethsNeonRingsAutoSplitterComponent::LethsNeonRingsAutoSplitterComponent(BakkesMod::Plugin::BakkesModPlugin *plugin)
+LethsNeonRingsAutoSplitterComponent::LethsNeonRingsAutoSplitterComponent(NetcodePlugin *plugin)
         : AutoSplitterComponent(plugin),
           level(),
           timing()
@@ -63,7 +63,7 @@ std::string LethsNeonRingsAutoSplitterComponent::getSplitDescription()
 
 std::string LethsNeonRingsAutoSplitterComponent::getResetDescription()
 {
-    return "The timer will reset when you press the reset map button or exit to the main menu.";
+    return "The timer will reset after leaving the map.";
 }
 
 std::string LethsNeonRingsAutoSplitterComponent::getDebugText()

--- a/src/components/maptools/leth/LethsNeonRingsMapToolsComponent.cpp
+++ b/src/components/maptools/leth/LethsNeonRingsMapToolsComponent.cpp
@@ -1,7 +1,7 @@
 #include "LethsNeonRingsMapToolsComponent.h"
 #include "LethsNeonRingsAutoSplitterComponent.h"
 
-LethsNeonRingsMapToolsComponent::LethsNeonRingsMapToolsComponent(BakkesMod::Plugin::BakkesModPlugin *plugin)
+LethsNeonRingsMapToolsComponent::LethsNeonRingsMapToolsComponent(NetcodePlugin *plugin)
         : MapToolsComponent(plugin, std::make_shared<LethsNeonRingsAutoSplitterComponent>(plugin),
                             "Leth's Neon Rings", "lethsneon", 20)
 {

--- a/src/components/maptools/leth/LethsNeonRingsMapToolsComponent.h
+++ b/src/components/maptools/leth/LethsNeonRingsMapToolsComponent.h
@@ -5,7 +5,7 @@
 class LethsNeonRingsMapToolsComponent : public MapToolsComponent
 {
 public:
-    explicit LethsNeonRingsMapToolsComponent(BakkesMod::Plugin::BakkesModPlugin *plugin);
+    explicit LethsNeonRingsMapToolsComponent(NetcodePlugin *plugin);
 
 protected:
     void resetMap() override;

--- a/src/components/maptools/minigolf/MinigolfAutoSplitterComponent.cpp
+++ b/src/components/maptools/minigolf/MinigolfAutoSplitterComponent.cpp
@@ -1,0 +1,63 @@
+#include "MinigolfAutoSplitterComponent.h"
+
+MinigolfAutoSplitterComponent::MinigolfAutoSplitterComponent(NetcodePlugin* plugin)
+    : AutoSplitterComponent(plugin),
+    mapStarted(false)
+{
+
+}
+
+void MinigolfAutoSplitterComponent::onEnable()
+{
+    this->mapStarted = false;
+}
+
+void MinigolfAutoSplitterComponent::update(const std::string& eventName, bool post, void* params)
+{
+    if (eventName == "Function TAGame.GameEvent_Soccar_TA.InitGame" && post)
+    {
+        this->mapStarted = true;
+    }
+    if (eventName == "Function TAGame.Car_TA.SetVehicleInput" && post)
+    {
+        if (this->segment != 0 || !this->mapStarted) return;
+        auto car = this->plugin->gameWrapper->GetLocalCar();
+        if (!car) return;
+        if (car.GetVelocity().magnitude() != 0)
+            this->start();
+    }
+    if (eventName == "Function TAGame.Ball_TA.Explode" && post)
+    {
+        if (1 <= this->segment && this->segment <= 9) {
+            this->split();
+        }
+    }
+    if (eventName == "Function TAGame.GameEvent_Soccar_TA.Destroyed" && post)
+    {
+        this->mapStarted = false;
+        this->reset();
+    }
+}
+
+std::string MinigolfAutoSplitterComponent::getStartDescription()
+{
+    return "The timer will start when the map loads.";
+}
+
+std::string MinigolfAutoSplitterComponent::getSplitDescription()
+{
+    return "The timer will split after a goal is scored.";
+}
+
+std::string MinigolfAutoSplitterComponent::getResetDescription()
+{
+    return "The timer will reset after leaving the match.";
+}
+
+std::string MinigolfAutoSplitterComponent::getDebugText()
+{
+    std::stringstream ss;
+    ss << "Minigolf Auto Splitter (Debug)" << std::endl;
+    ss << "mapStarted = " << this->mapStarted << std::endl;
+    return ss.str();
+}

--- a/src/components/maptools/minigolf/MinigolfAutoSplitterComponent.cpp
+++ b/src/components/maptools/minigolf/MinigolfAutoSplitterComponent.cpp
@@ -46,7 +46,7 @@ std::string MinigolfAutoSplitterComponent::getStartDescription()
 
 std::string MinigolfAutoSplitterComponent::getSplitDescription()
 {
-    return "The timer will split after a goal is scored.";
+    return "The timer will split after a goal is scored (9 splits in total).";
 }
 
 std::string MinigolfAutoSplitterComponent::getResetDescription()

--- a/src/components/maptools/minigolf/MinigolfAutoSplitterComponent.h
+++ b/src/components/maptools/minigolf/MinigolfAutoSplitterComponent.h
@@ -1,0 +1,18 @@
+#include "../AutoSplitterComponent.h"
+
+class MinigolfAutoSplitterComponent : public AutoSplitterComponent
+{
+private:
+    bool mapStarted;
+
+public:
+    explicit MinigolfAutoSplitterComponent(NetcodePlugin* plugin);
+
+    void onEnable() override;
+    void update(const std::string& eventName, bool post, void* params) override;
+
+    std::string getStartDescription() override;
+    std::string getSplitDescription() override;
+    std::string getResetDescription() override;
+    std::string getDebugText() override;
+};

--- a/src/components/maptools/minigolf/MinigolfMapToolsComponent.cpp
+++ b/src/components/maptools/minigolf/MinigolfMapToolsComponent.cpp
@@ -1,0 +1,19 @@
+#include "MinigolfMapToolsComponent.h"
+#include "MinigolfAutoSplitterComponent.h"
+
+MinigolfMapToolsComponent::MinigolfMapToolsComponent(NetcodePlugin* plugin)
+    : MapToolsComponent(plugin, std::make_shared<MinigolfAutoSplitterComponent>(plugin),
+        "Minigolf", "minigolf", 0)
+{
+
+}
+
+void MinigolfMapToolsComponent::resetMap()
+{
+    this->plugin->gameWrapper->ExecuteUnrealCommand("servertravel ?");
+}
+
+void MinigolfMapToolsComponent::checkpoint(int checkpoint)
+{
+
+}

--- a/src/components/maptools/minigolf/MinigolfMapToolsComponent.h
+++ b/src/components/maptools/minigolf/MinigolfMapToolsComponent.h
@@ -1,0 +1,11 @@
+#include "../MapToolsComponent.h"
+
+class MinigolfMapToolsComponent : public MapToolsComponent
+{
+public:
+    explicit MinigolfMapToolsComponent(NetcodePlugin* plugin);
+
+protected:
+    void resetMap() override;
+    void checkpoint(int checkpoint) override;
+};

--- a/src/components/maptools/panic/PanicsAirRaceBeachAutoSplitterComponent.cpp
+++ b/src/components/maptools/panic/PanicsAirRaceBeachAutoSplitterComponent.cpp
@@ -1,6 +1,6 @@
 #include "PanicsAirRaceBeachAutoSplitterComponent.h"
 
-PanicsAirRaceBeachAutoSplitterComponent::PanicsAirRaceBeachAutoSplitterComponent(BakkesMod::Plugin::BakkesModPlugin *plugin)
+PanicsAirRaceBeachAutoSplitterComponent::PanicsAirRaceBeachAutoSplitterComponent(NetcodePlugin *plugin)
         : AutoSplitterComponent(plugin),
           rings(),
           checkpoint()

--- a/src/components/maptools/panic/PanicsAirRaceBeachAutoSplitterComponent.h
+++ b/src/components/maptools/panic/PanicsAirRaceBeachAutoSplitterComponent.h
@@ -9,7 +9,7 @@ private:
     int checkpoint;
 
 public:
-    explicit PanicsAirRaceBeachAutoSplitterComponent(BakkesMod::Plugin::BakkesModPlugin *plugin);
+    explicit PanicsAirRaceBeachAutoSplitterComponent(NetcodePlugin *plugin);
 
 protected:
     void onEnable() override;

--- a/src/components/maptools/panic/PanicsAirRaceBeachMapToolsComponent.cpp
+++ b/src/components/maptools/panic/PanicsAirRaceBeachMapToolsComponent.cpp
@@ -1,7 +1,7 @@
 #include "PanicsAirRaceBeachMapToolsComponent.h"
 #include "PanicsAirRaceBeachAutoSplitterComponent.h"
 
-PanicsAirRaceBeachMapToolsComponent::PanicsAirRaceBeachMapToolsComponent(BakkesMod::Plugin::BakkesModPlugin *plugin)
+PanicsAirRaceBeachMapToolsComponent::PanicsAirRaceBeachMapToolsComponent(NetcodePlugin *plugin)
         : MapToolsComponent(plugin, std::make_shared<PanicsAirRaceBeachAutoSplitterComponent>(plugin),
                             "Panic's Air Race Beach", "panicsbeach", 11)
 {

--- a/src/components/maptools/panic/PanicsAirRaceBeachMapToolsComponent.h
+++ b/src/components/maptools/panic/PanicsAirRaceBeachMapToolsComponent.h
@@ -5,7 +5,7 @@
 class PanicsAirRaceBeachMapToolsComponent : public MapToolsComponent
 {
 public:
-    explicit PanicsAirRaceBeachMapToolsComponent(BakkesMod::Plugin::BakkesModPlugin *plugin);
+    explicit PanicsAirRaceBeachMapToolsComponent(NetcodePlugin *plugin);
 
 protected:
     void resetMap() override;

--- a/src/components/maptools/speedjump/rings/SpeedJumpRings1AutoSplitterComponent.cpp
+++ b/src/components/maptools/speedjump/rings/SpeedJumpRings1AutoSplitterComponent.cpp
@@ -1,6 +1,6 @@
 #include "SpeedJumpRings1AutoSplitterComponent.h"
 
-SpeedJumpRings1AutoSplitterComponent::SpeedJumpRings1AutoSplitterComponent(BakkesMod::Plugin::BakkesModPlugin *plugin)
+SpeedJumpRings1AutoSplitterComponent::SpeedJumpRings1AutoSplitterComponent(NetcodePlugin *plugin)
         : AutoSplitterComponent(plugin),
           rings()
 {

--- a/src/components/maptools/speedjump/rings/SpeedJumpRings1AutoSplitterComponent.h
+++ b/src/components/maptools/speedjump/rings/SpeedJumpRings1AutoSplitterComponent.h
@@ -8,7 +8,7 @@ private:
     int rings;
 
 public:
-    explicit SpeedJumpRings1AutoSplitterComponent(BakkesMod::Plugin::BakkesModPlugin *plugin);
+    explicit SpeedJumpRings1AutoSplitterComponent(NetcodePlugin *plugin);
 
     void onEnable() override;
     void update(const std::string &eventName, bool post, void *params) override;

--- a/src/components/maptools/speedjump/rings/SpeedJumpRings1MapToolsComponent.cpp
+++ b/src/components/maptools/speedjump/rings/SpeedJumpRings1MapToolsComponent.cpp
@@ -1,7 +1,7 @@
 #include "SpeedJumpRings1MapToolsComponent.h"
 #include "SpeedJumpRings1AutoSplitterComponent.h"
 
-SpeedJumpRings1MapToolsComponent::SpeedJumpRings1MapToolsComponent(BakkesMod::Plugin::BakkesModPlugin *plugin)
+SpeedJumpRings1MapToolsComponent::SpeedJumpRings1MapToolsComponent(NetcodePlugin *plugin)
         : MapToolsComponent(plugin, std::make_shared<SpeedJumpRings1AutoSplitterComponent>(plugin),
                             "Speed Jump Rings 1", "sjr1", 0)
 {

--- a/src/components/maptools/speedjump/rings/SpeedJumpRings1MapToolsComponent.h
+++ b/src/components/maptools/speedjump/rings/SpeedJumpRings1MapToolsComponent.h
@@ -5,7 +5,7 @@
 class SpeedJumpRings1MapToolsComponent : public MapToolsComponent
 {
 public:
-    explicit SpeedJumpRings1MapToolsComponent(BakkesMod::Plugin::BakkesModPlugin *plugin);
+    explicit SpeedJumpRings1MapToolsComponent(NetcodePlugin *plugin);
 
 protected:
     void resetMap() override;

--- a/src/components/maptools/speedjump/rings/SpeedJumpRings2AutoSplitterComponent.cpp
+++ b/src/components/maptools/speedjump/rings/SpeedJumpRings2AutoSplitterComponent.cpp
@@ -1,6 +1,6 @@
 #include "SpeedJumpRings2AutoSplitterComponent.h"
 
-SpeedJumpRings2AutoSplitterComponent::SpeedJumpRings2AutoSplitterComponent(BakkesMod::Plugin::BakkesModPlugin *plugin)
+SpeedJumpRings2AutoSplitterComponent::SpeedJumpRings2AutoSplitterComponent(NetcodePlugin *plugin)
         : AutoSplitterComponent(plugin),
           hitBoxes(),
           timer()

--- a/src/components/maptools/speedjump/rings/SpeedJumpRings2AutoSplitterComponent.h
+++ b/src/components/maptools/speedjump/rings/SpeedJumpRings2AutoSplitterComponent.h
@@ -10,7 +10,7 @@ private:
     std::string timer;
 
 public:
-    explicit SpeedJumpRings2AutoSplitterComponent(BakkesMod::Plugin::BakkesModPlugin *plugin);
+    explicit SpeedJumpRings2AutoSplitterComponent(NetcodePlugin *plugin);
 
     void onEnable() override;
     void update(const std::string &eventName, bool post, void *params) override;

--- a/src/components/maptools/speedjump/rings/SpeedJumpRings2MapToolsComponent.cpp
+++ b/src/components/maptools/speedjump/rings/SpeedJumpRings2MapToolsComponent.cpp
@@ -1,7 +1,7 @@
 #include "SpeedJumpRings2MapToolsComponent.h"
 #include "SpeedJumpRings2AutoSplitterComponent.h"
 
-SpeedJumpRings2MapToolsComponent::SpeedJumpRings2MapToolsComponent(BakkesMod::Plugin::BakkesModPlugin *plugin)
+SpeedJumpRings2MapToolsComponent::SpeedJumpRings2MapToolsComponent(NetcodePlugin *plugin)
         : MapToolsComponent(plugin, std::make_shared<SpeedJumpRings2AutoSplitterComponent>(plugin),
                             "Speed Jump Rings 2", "sjr2", 11)
 {

--- a/src/components/maptools/speedjump/rings/SpeedJumpRings2MapToolsComponent.h
+++ b/src/components/maptools/speedjump/rings/SpeedJumpRings2MapToolsComponent.h
@@ -5,7 +5,7 @@
 class SpeedJumpRings2MapToolsComponent : public MapToolsComponent
 {
 public:
-    explicit SpeedJumpRings2MapToolsComponent(BakkesMod::Plugin::BakkesModPlugin *plugin);
+    explicit SpeedJumpRings2MapToolsComponent(NetcodePlugin *plugin);
 
 protected:
     void resetMap() override;

--- a/src/components/maptools/speedjump/rings/SpeedJumpRings3AutoSplitterComponent.cpp
+++ b/src/components/maptools/speedjump/rings/SpeedJumpRings3AutoSplitterComponent.cpp
@@ -1,6 +1,6 @@
 #include "SpeedJumpRings3AutoSplitterComponent.h"
 
-SpeedJumpRings3AutoSplitterComponent::SpeedJumpRings3AutoSplitterComponent(BakkesMod::Plugin::BakkesModPlugin *plugin)
+SpeedJumpRings3AutoSplitterComponent::SpeedJumpRings3AutoSplitterComponent(NetcodePlugin *plugin)
         : AutoSplitterComponent(plugin),
           timer(),
           level()

--- a/src/components/maptools/speedjump/rings/SpeedJumpRings3AutoSplitterComponent.h
+++ b/src/components/maptools/speedjump/rings/SpeedJumpRings3AutoSplitterComponent.h
@@ -9,7 +9,7 @@ private:
     int level;
 
 public:
-    explicit SpeedJumpRings3AutoSplitterComponent(BakkesMod::Plugin::BakkesModPlugin *plugin);
+    explicit SpeedJumpRings3AutoSplitterComponent(NetcodePlugin *plugin);
 
     void onEnable() override;
     void update(const std::string &eventName, bool post, void *params) override;

--- a/src/components/maptools/speedjump/rings/SpeedJumpRings3MapToolsComponent.cpp
+++ b/src/components/maptools/speedjump/rings/SpeedJumpRings3MapToolsComponent.cpp
@@ -1,7 +1,7 @@
 #include "SpeedJumpRings3MapToolsComponent.h"
 #include "SpeedJumpRings3AutoSplitterComponent.h"
 
-SpeedJumpRings3MapToolsComponent::SpeedJumpRings3MapToolsComponent(BakkesMod::Plugin::BakkesModPlugin *plugin)
+SpeedJumpRings3MapToolsComponent::SpeedJumpRings3MapToolsComponent(NetcodePlugin *plugin)
         : MapToolsComponent(plugin, std::make_shared<SpeedJumpRings3AutoSplitterComponent>(plugin),
                             "Speed Jump Rings 3", "sjr3", 14)
 {

--- a/src/components/maptools/speedjump/rings/SpeedJumpRings3MapToolsComponent.h
+++ b/src/components/maptools/speedjump/rings/SpeedJumpRings3MapToolsComponent.h
@@ -5,7 +5,7 @@
 class SpeedJumpRings3MapToolsComponent : public MapToolsComponent
 {
 public:
-    explicit SpeedJumpRings3MapToolsComponent(BakkesMod::Plugin::BakkesModPlugin *plugin);
+    explicit SpeedJumpRings3MapToolsComponent(NetcodePlugin *plugin);
 
 protected:
     void resetMap() override;

--- a/src/components/maptools/speedjump/trials/SpeedJumpTrials1AutoSplitterComponent.cpp
+++ b/src/components/maptools/speedjump/trials/SpeedJumpTrials1AutoSplitterComponent.cpp
@@ -1,6 +1,6 @@
 #include "SpeedJumpTrials1AutoSplitterComponent.h"
 
-SpeedJumpTrials1AutoSplitterComponent::SpeedJumpTrials1AutoSplitterComponent(BakkesMod::Plugin::BakkesModPlugin *plugin)
+SpeedJumpTrials1AutoSplitterComponent::SpeedJumpTrials1AutoSplitterComponent(NetcodePlugin *plugin)
         : AutoSplitterComponent(plugin),
           level(),
           resetMap()
@@ -40,8 +40,7 @@ void SpeedJumpTrials1AutoSplitterComponent::update(const std::string &eventName,
         }
         else if (2 <= this->segment && this->segment <= 9)
         {
-            // TODO CHECK SEG
-            if (this->level == (previousLevel + 1))
+            if (this->level == (previousLevel + 1) && this->level == (this->segment + 1))
             {
                 this->split();
             }

--- a/src/components/maptools/speedjump/trials/SpeedJumpTrials1AutoSplitterComponent.h
+++ b/src/components/maptools/speedjump/trials/SpeedJumpTrials1AutoSplitterComponent.h
@@ -9,7 +9,7 @@ private:
     bool resetMap;
 
 public:
-    explicit SpeedJumpTrials1AutoSplitterComponent(BakkesMod::Plugin::BakkesModPlugin *plugin);
+    explicit SpeedJumpTrials1AutoSplitterComponent(NetcodePlugin *plugin);
 
     void onEnable() override;
     void update(const std::string &eventName, bool post, void *params) override;

--- a/src/components/maptools/speedjump/trials/SpeedJumpTrials1MapToolsComponent.cpp
+++ b/src/components/maptools/speedjump/trials/SpeedJumpTrials1MapToolsComponent.cpp
@@ -1,7 +1,7 @@
 #include "SpeedJumpTrials1MapToolsComponent.h"
 #include "SpeedJumpTrials1AutoSplitterComponent.h"
 
-SpeedJumpTrials1MapToolsComponent::SpeedJumpTrials1MapToolsComponent(BakkesMod::Plugin::BakkesModPlugin *plugin)
+SpeedJumpTrials1MapToolsComponent::SpeedJumpTrials1MapToolsComponent(NetcodePlugin *plugin)
         : MapToolsComponent(plugin, std::make_shared<SpeedJumpTrials1AutoSplitterComponent>(plugin),
                             "Speed Jump Trials 1", "sjt1", 10)
 {

--- a/src/components/maptools/speedjump/trials/SpeedJumpTrials1MapToolsComponent.h
+++ b/src/components/maptools/speedjump/trials/SpeedJumpTrials1MapToolsComponent.h
@@ -5,7 +5,7 @@
 class SpeedJumpTrials1MapToolsComponent : public MapToolsComponent
 {
 public:
-    explicit SpeedJumpTrials1MapToolsComponent(BakkesMod::Plugin::BakkesModPlugin *plugin);
+    explicit SpeedJumpTrials1MapToolsComponent(NetcodePlugin *plugin);
 
 protected:
     void resetMap() override;

--- a/src/components/maptools/tutorial/TutorialAdvancedAutoSplitterComponent.cpp
+++ b/src/components/maptools/tutorial/TutorialAdvancedAutoSplitterComponent.cpp
@@ -1,6 +1,6 @@
 #include "TutorialAdvancedAutoSplitterComponent.h"
 
-TutorialAdvancedAutoSplitterComponent::TutorialAdvancedAutoSplitterComponent(BakkesMod::Plugin::BakkesModPlugin *plugin)
+TutorialAdvancedAutoSplitterComponent::TutorialAdvancedAutoSplitterComponent(NetcodePlugin *plugin)
         : AutoSplitterComponent(plugin),
           isInTutorial(false),
           segment4GoalsScored(0),

--- a/src/components/maptools/tutorial/TutorialAdvancedAutoSplitterComponent.h
+++ b/src/components/maptools/tutorial/TutorialAdvancedAutoSplitterComponent.h
@@ -10,7 +10,7 @@ private:
     int segment5GoalsScored;
 
 public:
-    explicit TutorialAdvancedAutoSplitterComponent(BakkesMod::Plugin::BakkesModPlugin *plugin);
+    explicit TutorialAdvancedAutoSplitterComponent(NetcodePlugin *plugin);
 
 protected:
     void update(const std::string &eventName, bool post, void *params) override;

--- a/src/components/maptools/tutorial/TutorialAdvancedMapToolsComponent.cpp
+++ b/src/components/maptools/tutorial/TutorialAdvancedMapToolsComponent.cpp
@@ -1,7 +1,7 @@
 #include "TutorialAdvancedMapToolsComponent.h"
 #include "TutorialAdvancedAutoSplitterComponent.h"
 
-TutorialAdvancedMapToolsComponent::TutorialAdvancedMapToolsComponent(BakkesMod::Plugin::BakkesModPlugin *plugin)
+TutorialAdvancedMapToolsComponent::TutorialAdvancedMapToolsComponent(NetcodePlugin *plugin)
         : MapToolsComponent(plugin, std::make_shared<TutorialAdvancedAutoSplitterComponent>(plugin),
                             "Tutorial Advanced", "tutorialadvanced", 5)
 {

--- a/src/components/maptools/tutorial/TutorialAdvancedMapToolsComponent.h
+++ b/src/components/maptools/tutorial/TutorialAdvancedMapToolsComponent.h
@@ -5,7 +5,7 @@
 class TutorialAdvancedMapToolsComponent : public MapToolsComponent
 {
 public:
-    explicit TutorialAdvancedMapToolsComponent(BakkesMod::Plugin::BakkesModPlugin *plugin);
+    explicit TutorialAdvancedMapToolsComponent(NetcodePlugin *plugin);
 
 protected:
     void resetMap() override;

--- a/src/components/maptools/tutorial/TutorialBasicAutoSplitterComponent.cpp
+++ b/src/components/maptools/tutorial/TutorialBasicAutoSplitterComponent.cpp
@@ -1,6 +1,6 @@
 #include "TutorialBasicAutoSplitterComponent.h"
 
-TutorialBasicAutoSplitterComponent::TutorialBasicAutoSplitterComponent(BakkesMod::Plugin::BakkesModPlugin *plugin)
+TutorialBasicAutoSplitterComponent::TutorialBasicAutoSplitterComponent(NetcodePlugin *plugin)
         : AutoSplitterComponent(plugin),
           isInTutorial(false)
 {

--- a/src/components/maptools/tutorial/TutorialBasicAutoSplitterComponent.h
+++ b/src/components/maptools/tutorial/TutorialBasicAutoSplitterComponent.h
@@ -8,7 +8,7 @@ private:
     bool isInTutorial;
 
 public:
-    explicit TutorialBasicAutoSplitterComponent(BakkesMod::Plugin::BakkesModPlugin *plugin);
+    explicit TutorialBasicAutoSplitterComponent(NetcodePlugin *plugin);
 
 protected:
     void update(const std::string &eventName, bool post, void *params) override;

--- a/src/components/maptools/tutorial/TutorialBasicMapToolsComponent.cpp
+++ b/src/components/maptools/tutorial/TutorialBasicMapToolsComponent.cpp
@@ -1,7 +1,7 @@
 #include "TutorialBasicMapToolsComponent.h"
 #include "TutorialBasicAutoSplitterComponent.h"
 
-TutorialBasicMapToolsComponent::TutorialBasicMapToolsComponent(BakkesMod::Plugin::BakkesModPlugin *plugin)
+TutorialBasicMapToolsComponent::TutorialBasicMapToolsComponent(NetcodePlugin *plugin)
         : MapToolsComponent(plugin, std::make_shared<TutorialBasicAutoSplitterComponent>(plugin),
                             "Tutorial Basic", "tutorialbasic", 6)
 {

--- a/src/components/savestates/RewindComponent.cpp
+++ b/src/components/savestates/RewindComponent.cpp
@@ -1,6 +1,6 @@
 #include "RewindComponent.h"
 
-RewindComponent::RewindComponent(BakkesMod::Plugin::BakkesModPlugin *plugin)
+RewindComponent::RewindComponent(NetcodePlugin *plugin)
         : PluginComponentBase(plugin),
           rewindBuffer(6.0f),
           previousSaveTime()

--- a/src/components/savestates/RewindComponent.h
+++ b/src/components/savestates/RewindComponent.h
@@ -11,7 +11,7 @@ private:
     float previousSaveTime;
 
 public:
-    explicit RewindComponent(BakkesMod::Plugin::BakkesModPlugin *plugin);
+    explicit RewindComponent(NetcodePlugin *plugin);
 
     void render() override;
     void onEvent(const std::string &eventName, bool post, void *params) override;

--- a/src/components/savestates/SaveStatesComponent.cpp
+++ b/src/components/savestates/SaveStatesComponent.cpp
@@ -3,7 +3,7 @@
 const std::string SaveStatesComponent::SaveStateCVarName = "speedrun_savestate_save";
 const std::string SaveStatesComponent::LoadStateCVarName = "speedrun_savestate_load";
 
-SaveStatesComponent::SaveStatesComponent(BakkesMod::Plugin::BakkesModPlugin *plugin)
+SaveStatesComponent::SaveStatesComponent(NetcodePlugin *plugin)
         : PluginComponentBase(plugin),
           isGameStateSaved(false),
           gameSaveState()

--- a/src/components/savestates/SaveStatesComponent.h
+++ b/src/components/savestates/SaveStatesComponent.h
@@ -14,7 +14,7 @@ private:
     GameState gameSaveState;
 
 public:
-    explicit SaveStatesComponent(BakkesMod::Plugin::BakkesModPlugin *plugin);
+    explicit SaveStatesComponent(NetcodePlugin *plugin);
 
     void render() override;
 

--- a/src/utils/NetcodeManager.cpp
+++ b/src/utils/NetcodeManager.cpp
@@ -1,0 +1,276 @@
+#include "NetcodeManager.h"
+#include "bakkesmod/wrappers/PluginManagerWrapper.h"
+#include <sstream>
+#include <filesystem>
+
+// Constructor //
+NetcodeManager::NetcodeManager
+(
+    std::shared_ptr<CVarManagerWrapper> InCvarManager,
+    std::shared_ptr<GameWrapper> InGameWrapper,
+    BakkesMod::Plugin::PluginInfo InPluginExports,
+    std::function<void (const std::string& Message, PriWrapper Sender)> InMessageHandlingFunction
+) : cvarManager(InCvarManager), gameWrapper(InGameWrapper), PluginExports(InPluginExports), MessageHandlingFunction(InMessageHandlingFunction)
+{
+    bIsGood = false;
+    NetcodeLoadLoop(true);
+}
+
+// Message Sending //
+void NetcodeManager::SendNewMessage(const std::string& InMessage)
+{
+    if(!CheckIfGood(__FUNCTION__)) { return; }
+    
+    std::string OutMessage = std::string("[") + PluginExports.className + "]" + InMessage;
+
+    NETLOGC("Sending NetcodeManager message: " + OutMessage);
+
+    //Notify NetcodePlugin that this client wants to send a message
+    cvarManager->getCvar(CVAR_MESSAGE_OUT).setValue(OutMessage);
+}
+
+
+// NetcodePlugin Loading //
+void NetcodeManager::NetcodeLoadLoop(bool bResetAttempts)
+{
+    //Check if NetcodeManager is already good to go
+    if(CheckIfGood(__FUNCTION__)) { return; }
+
+    //Limit the number of times this loop fires to 20 attempts
+    static int LoadAttempts = 0;
+    if(bResetAttempts) { LoadAttempts = 0; }
+    ++LoadAttempts;
+    if(LoadAttempts >= 20) { return; }
+
+    //Check if NetcodePlugin is loaded. Handle the result
+    if(IsNetcodeLoaded())
+    {
+        OnSuccessfulLoadDetection();
+    }
+    else
+    {
+        //NetcodePlugin is not loaded. Check if NetcodePlugin.dll exists
+        if(DoesNetcodePluginExist())
+        {
+            cvarManager->executeCommand("plugin load NetcodePlugin", false);
+        }
+        else
+        {
+            cvarManager->executeCommand("bpm_install 166", false);
+        }
+
+        //Check again to see if the plugin is loaded in 2 seconds
+        gameWrapper->SetTimeout(std::bind(&NetcodeManager::NetcodeLoadLoop, this, false), 2.f);
+    }
+}
+
+bool NetcodeManager::DoesNetcodePluginExist()
+{
+    return std::filesystem::exists(gameWrapper->GetBakkesModPath() / "plugins" / "NetcodePlugin.dll");
+}
+
+bool NetcodeManager::IsNetcodeLoaded()
+{
+    PluginManagerWrapper PluginManager = gameWrapper->GetPluginManager();
+    if(PluginManager.memory_address == NULL) { return false; }
+
+    auto* PluginList = PluginManager.GetLoadedPlugins();
+    for(const auto& ThisPlugin : *PluginList)
+    {
+        if(std::string(ThisPlugin->_details->className) == "NetcodePlugin")
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+void NetcodeManager::OnSuccessfulLoadDetection()
+{
+    //Get log level cvar from NetcodePlugin
+    CVarWrapper LogLevelCvar = cvarManager->getCvar(CVAR_LOG_LEVEL);
+    if(LogLevelCvar.IsNull())
+    {
+        //Can't use NETLOGA here because it requires CvarLogLevel to be set up
+        cvarManager->log("NetcodePlugin is loaded, but could not find cvar " + LogLevelCvar.getCVarName());
+        return;
+    }
+
+    //Set up log level
+    CvarLogLevel = std::make_shared<int>(1);
+    LogLevelCvar.bindTo(CvarLogLevel);
+
+    //Check if NetcodePlugin cvars are correct
+    CVarWrapper IncomingMessageCvar = cvarManager->getCvar(CVAR_MESSAGE_IN);
+    CVarWrapper OutgoingMessageCvar = cvarManager->getCvar(CVAR_MESSAGE_OUT);
+    if(IncomingMessageCvar.IsNull())
+    {
+        NETLOGA("NetcodePlugin is loaded, but could not find cvar " + IncomingMessageCvar.getCVarName());
+        return;
+    }
+    if(OutgoingMessageCvar.IsNull())
+    {
+        NETLOGA("NetcodePlugin is loaded, but could not find cvar " + OutgoingMessageCvar.getCVarName());
+        return;
+    }
+
+    //Subscribe to incoming message cvar to see when it has changed, indicating an incoming messaage
+    IncomingMessageCvar.addOnValueChanged(std::bind(&NetcodeManager::ReceiveMessage, this));
+
+    //NetcodeManager is all set and can fully function
+    bIsGood = true;
+
+    NETLOGA("NetcodeManager has successfully detected that NetcodePlugin is loaded. Ready to go.");
+}
+
+
+// General Functionality //
+bool NetcodeManager::CheckIfGood(const char* InFunctionName)
+{
+    if(!bIsGood)
+    {
+        cvarManager->log(std::string("NetcodeManager function (") + InFunctionName + ") failed. NetcodePlugin is not loaded.");
+        return false;
+    }
+
+    return true;
+}
+
+
+// Determining Authority //
+ServerWrapper NetcodeManager::GetCurrentGameState()
+{
+    if(gameWrapper->IsInReplay())
+        return gameWrapper->GetGameEventAsReplay().memory_address;
+    else if(gameWrapper->IsInOnlineGame())
+        return gameWrapper->GetOnlineGame();
+    else
+        return gameWrapper->GetGameEventAsServer();
+}
+
+NetcodeManager::EAuthority NetcodeManager::GetMatchAuthority()
+{
+    ServerWrapper Server = GetCurrentGameState();
+    if(!Server.IsNull())
+    {
+        GameSettingPlaylistWrapper GSPW = Server.GetPlaylist();
+        if(GSPW.memory_address != NULL && GSPW.IsLanMatch())
+        {
+            if(gameWrapper->IsInOnlineGame())
+            {
+                return EAuthority::Client;
+            }
+
+            return EAuthority::Host;
+        }
+    }
+
+    return EAuthority::None;
+}
+
+
+// Message Receiving and Parsing //
+void NetcodeManager::ReceiveMessage()
+{
+    if(!CheckIfGood(__FUNCTION__)) { return; }
+
+    std::string IncomingMessage = cvarManager->getCvar(CVAR_MESSAGE_IN).getStringValue();
+    NETLOGC("Receiving message: " + IncomingMessage);
+
+    //Get all data from the message
+    ParsedMessageData MessageData = ParseIncomingMessage(IncomingMessage);
+    
+    //Only handle messages that correspond with this plugin
+    if(MessageData.PluginClassName != PluginExports.className)
+    {
+        return;
+    }
+
+    LogMessageData(MessageData);
+
+    //Notify the plugin that this message is intended for this plugin
+    MessageHandlingFunction(MessageData.MessageContent, MessageData.Sender);
+}
+
+NetcodeManager::ParsedMessageData NetcodeManager::ParseIncomingMessage(const std::string& IncomingMessage)
+{
+    //Incoming message format should be as follows:
+    //[PluginName][SenderPriAddress]Message
+
+    //Split message based on matched brackets [] and fill data struct
+    size_t StartPoint = 0, EndPoint = 0;
+    ParsedMessageData Output;
+
+    //Get class name
+    Output.PluginClassName = GetContentFromBrackets(IncomingMessage, StartPoint, EndPoint);
+    StartPoint = EndPoint + 1;
+
+    //Get sender pri
+    Output.Sender = GetSenderPri(GetContentFromBrackets(IncomingMessage, StartPoint, EndPoint));
+    StartPoint = EndPoint + 1;
+
+    //Get message content
+    Output.MessageContent = IncomingMessage.substr(StartPoint, INT_MAX);
+
+    return Output;
+}
+
+std::string NetcodeManager::GetContentFromBrackets(const std::string& IncomingMessage, const size_t InStartPoint, size_t& OutEndPoint)
+{
+    std::string Output;
+
+    if(!IncomingMessage.empty() && InStartPoint < IncomingMessage.size())
+    {
+        if(IncomingMessage.at(InStartPoint) == '[')
+        {
+            OutEndPoint = IncomingMessage.find_first_of(']', InStartPoint);
+            if(OutEndPoint != std::string::npos)
+            {
+                Output = IncomingMessage.substr(InStartPoint + 1, OutEndPoint - InStartPoint - 1);
+            }
+        }
+    }
+
+    return Output;
+}
+
+PriWrapper NetcodeManager::GetSenderPri(const std::string& InChatterPriAddressString)
+{
+    uintptr_t PriAddress = NULL;
+
+    if(!InChatterPriAddressString.empty() && InChatterPriAddressString != "0")
+    {
+        std::stringstream ChatterAddressStream(InChatterPriAddressString);
+        ChatterAddressStream >> PriAddress;
+    }
+
+    return PriWrapper(PriAddress);
+}
+
+
+// Additional logging //
+void NetcodeManager::LogMessageData(ParsedMessageData InMessageData)
+{
+    std::string Output = "Parsed message:\n";
+
+    //Plugin name
+    Output += "PluginClassName: " + InMessageData.PluginClassName + '\n';
+
+    //Original chatter
+    Output += "Sender: ";
+    std::string OriginalChatterName = "NULL";
+    if(!InMessageData.Sender.IsNull())
+    {
+        if(!InMessageData.Sender.GetPlayerName().IsNull())
+        {
+            OriginalChatterName = InMessageData.Sender.GetPlayerName().ToString();
+        }
+    }
+    Output += OriginalChatterName + '\n';
+
+    //Message content
+    Output += "MessageContent: " + InMessageData.MessageContent;
+
+    NETLOGC(Output);
+}

--- a/src/utils/NetcodeManager.h
+++ b/src/utils/NetcodeManager.h
@@ -1,0 +1,97 @@
+#pragma once
+#include "bakkesmod/plugin/bakkesmodplugin.h"
+
+/*
+* NetcodeManager should be included in plugins that need to have two-way communication in LAN matches.
+* When a client sends a custom message to the host, that message will be automatically replicated to all the other clients.
+* 
+* When including NetcodeManager in a plugin, store it as a std::shared_ptr so that you can construct it in the onLoad function.
+*/
+
+class NetcodeManager
+{
+public:
+    //CONSTRUCTOR
+    // "InCvarManager" and "InGameWrapper" store the plugin's auto-included "cvarManager" and "gameWrapper" pointers
+    //
+    // "InPluginExports" stores the parent plugin's auto-included "exports" variable
+    //
+    // "InMessageHandlingFunction" stores a pointer to the plugin's message handling function
+    //     Example function: "void ParentPlugin::ReceiveMessage(const std::string& Message, PriWrapper Sender);"
+    //     Pass into constructor as: "std::bind(&ParentPlugin::ReceiveMessage, this, _1, _2)" where _1 and _2 are std::placeholders
+    //
+    // Example constructor inside onLoad function:
+    //     MyNetcodeManager = std::make_shared<NetcodeManager>(cvarManager, gameWrapper, exports, std::bind(&NetcodePluginExample::OnMessageReceived, this, _1, _2));
+    NetcodeManager
+    (
+        std::shared_ptr<CVarManagerWrapper> InCvarManager,
+        std::shared_ptr<GameWrapper> InGameWrapper,
+        BakkesMod::Plugin::PluginInfo InPluginExports,
+        std::function<void (const std::string& Message, PriWrapper Sender)> InMessageHandlingFunction
+    );
+
+    //MESSAGE SENDING
+    // NOTE: Message cannot be longer than 122 characters minus the length of the plugin's class name.
+    // Messages are limited to 128 characters total, and all messages have the following prefix: [PC][ClassName]
+    // PC (or PH) is internal info for NetcodePlugin's replication, and ClassName indicates that clients of this plugin should handle the message.
+    void SendNewMessage(const std::string& InMessage);
+
+
+
+//// NetcodeManager internals ////
+private:
+    //Cvars and macros from NetcodePlugin
+    #define CVAR_MESSAGE_OUT "NETCODE_Message_Out"
+    #define CVAR_MESSAGE_IN "NETCODE_Message_In"
+    #define CVAR_LOG_LEVEL "NETCODE_Log_Level"
+
+    std::shared_ptr<int> CvarLogLevel;
+
+    #define NETLOGA(x) if(*CvarLogLevel > 0) { cvarManager->log("(A: " + std::to_string(clock()) + ")   " + x); }
+    #define NETLOGB(x) if(*CvarLogLevel > 1) { cvarManager->log("(B: " + std::to_string(clock()) + ")   " + x); }
+    #define NETLOGC(x) if(*CvarLogLevel > 2) { cvarManager->log("(C: " + std::to_string(clock()) + ")   " + x); }
+
+    //Information about parent plugin
+    std::shared_ptr<CVarManagerWrapper> cvarManager;
+    std::shared_ptr<GameWrapper> gameWrapper;
+    BakkesMod::Plugin::PluginInfo PluginExports;
+    std::function<void (const std::string&, PriWrapper)> MessageHandlingFunction;
+
+    //Loading checks
+    void NetcodeLoadLoop(bool bResetAttempts);
+    bool IsNetcodeLoaded();
+    bool DoesNetcodePluginExist();
+    void OnSuccessfulLoadDetection();
+
+    //General functionality
+    bool bIsGood = false;
+    bool CheckIfGood(const char* InFunctionName);
+
+    //Determining authority
+    enum class EAuthority
+    {
+        None = 0,
+        Client,
+        Host
+    };
+    EAuthority GetMatchAuthority();
+    ServerWrapper GetCurrentGameState();
+
+    //Message receiving and parsing
+    struct ParsedMessageData
+    {
+        std::string PluginClassName;
+        PriWrapper  Sender = PriWrapper((uintptr_t)nullptr);
+        std::string MessageContent;
+    };
+    void ReceiveMessage();
+    ParsedMessageData ParseIncomingMessage(const std::string& IncomingMessage);
+    std::string GetContentFromBrackets(const std::string& IncomingMessage, const size_t InStartPoint, size_t& OutEndPoint);
+    PriWrapper GetSenderPri(const std::string& InPriAddressString);
+
+    //Additional logging
+    void LogMessageData(ParsedMessageData InMessageData);
+    
+    //No default constructor
+    NetcodeManager() = delete;
+};


### PR DESCRIPTION
Added Dribble 2 Overhaul, Egyptian Tomb, and Minigolf Autosplitters.

Added notifier for a global reset for one bind no matter the map

Refactored most constructors to include netcode support for coop runs

Made it to where autosplitters disable themselves when a new one is selected to prevent multiple split signals